### PR TITLE
version bump hassfeld to 0.3.11

### DIFF
--- a/custom_components/teufel_raumfeld/manifest.json
+++ b/custom_components/teufel_raumfeld/manifest.json
@@ -5,7 +5,7 @@
     "config_flow": true,
     "documentation": "https://github.com/B5r1oJ0A9G/teufel_raumfeld/wiki",
     "issue_tracker": "https://github.com/B5r1oJ0A9G/teufel_raumfeld/issues",
-    "requirements": ["hassfeld==0.3.10-alpha1"],
+    "requirements": ["hassfeld==0.3.11-alpha1"],
     "dependencies": [],
     "codeowners": ["@B5r1oJ0A9G"],
     "iot_class": "local_polling"


### PR DESCRIPTION
Homeassistant now uses async_upnp_client 0.27 which moved UpnpFactory to it's own submodule.

To make teufel_raumfeld and hassfeld work again with homeassistant 2022.04 and newer, these changes are necessary.

This should fix https://github.com/B5r1oJ0A9G/teufel_raumfeld/issues/31

This pull-request is super simple and the code is basically copied from the same fix for openhomedevice https://github.com/bazwilliams/openhomedevice/compare/2.0.1...2.0.2. Yet be aware I won't actually have the opportunity to actually test it for a few more days.
