### PR TITLE
Fix TTS

### DIFF
--- a/custom_components/teufel_raumfeld/media_player.py
+++ b/custom_components/teufel_raumfeld/media_player.py
@@ -23,7 +23,11 @@ from hassfeld.constants import (
 )
 import voluptuous as vol
 
+from homeassistant.components import media_source
 from homeassistant.components.media_player import MediaPlayerEntity
+from homeassistant.components.media_player.browse_media import (
+    async_process_play_media_url,
+)
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_VOLUME_LEVEL,
     MEDIA_TYPE_MUSIC,
@@ -439,10 +443,8 @@ class RaumfeldGroup(MediaPlayerEntity):
         if self._raumfeld.rooms_are_valid(self._rooms):
             if media_type in SUPPORTED_MEDIA_TYPES:
                 if media_type == MEDIA_TYPE_MUSIC:
-                    if media_id.startswith("http"):
-                        play_uri = media_id
-                    else:
-                        log_error("Unexpected URI for media type: %s" % media_type)
+                    play_item = await media_source.async_resolve_media(self.hass, media_id)
+                    play_uri = async_process_play_media_url(self.hass, play_item.url)
                 elif media_type in [
                     UPNP_CLASS_ALBUM,
                     UPNP_CLASS_LINE_IN,


### PR DESCRIPTION
I was playing with this integration and TTS and found there were errors using it because the URI for the cached TTS file was not resolved properly.
This is a quick hack to fix it mostly taken from [here](https://developers.home-assistant.io/docs/core/entity/media-player/#browse-media).
No idea if this fits any coding guidelines, that's why I just created it as a draft.

After fixing I played with an automation creating a snapshot then play the TTS, wait a moment and then restore. It seems the speaker has a problem returning the sound of the previous item, the player shows it is playing but it is quiet for a while until sound returns, no idea what the cause of that is or if it is fixable.