### PR TITLE
fix deprecation

### DIFF
--- a/custom_components/teufel_raumfeld/media_player.py
+++ b/custom_components/teufel_raumfeld/media_player.py
@@ -130,7 +130,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     raumfeld = hass.data[DOMAIN][config_entry.entry_id]
     room_names = raumfeld.get_rooms()
     room_groups = raumfeld.get_groups()
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = await hass.helpers.entity_registry.async_get()
     entity_entries = hass.helpers.entity_registry.async_entries_for_config_entry(
         entity_registry, config_entry.entry_id
     )


### PR DESCRIPTION
fix deprecation warning:
`Detected integration that uses deprecated "async_get_registry" to access entity registry, use async_get instead. Please report issue to the custom integration author for teufel_raumfeld using this method at custom_components/teufel_raumfeld/media_player.py, line 133: entity_registry = await hass.helpers.entity_registry.async_get_registry()`