### PR TITLE
Avoid deprecated function call for entry setup

### DIFF
--- a/custom_components/teufel_raumfeld/__init__.py
+++ b/custom_components/teufel_raumfeld/__init__.py
@@ -234,10 +234,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     log_debug("raumfeld.wsd=%s" % raumfeld.wsd)
     hass.data[DOMAIN][entry.entry_id] = raumfeld
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def async_handle_group(call):
         room_lst = call.data.get("room_names")


### PR DESCRIPTION
This pull request resolves two deprecation warnings when calling `async_forward_entry_setup`:

1. Use await
   ```Detected code that calls async_forward_entry_setup for integration teufel_raumfeld [..], during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1.```
2. Use async_forward_entry_setups over async_forward_entry_setup
  ```Detected that custom integration 'teufel_raumfeld' calls async_forward_entry_setup for integration, teufel_raumfeld […], which is deprecated and will stop working in Home Assistant 2025.6, await async_forward_entry_setups instead```

Check this post for further reading: https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

Hope you don't mind me not creating separate tickets for this small fix. ✌️

