### PR TITLE
Hide progress bar for live content

### DIFF
--- a/custom_components/teufel_raumfeld/media_player.py
+++ b/custom_components/teufel_raumfeld/media_player.py
@@ -296,7 +296,7 @@ class RaumfeldGroup(MediaPlayerEntity):
     @property
     def media_duration(self):
         """Duration of current playing media in seconds."""
-        return self._media_duration
+        return self._media_duration if self._media_duration else None
 
     @property
     def media_position(self):


### PR DESCRIPTION
With this PR, the progress bar will be hidden when playing live content (e.g. radio stations).

Currently, the progress bar for live content will be empty after restart (would be acceptable)
<img width="402" alt="Screenshot 2024-09-11 at 22 31 32" src="https://github.com/user-attachments/assets/9650635a-d8aa-4f0e-be9e-1b37518b56f5">

but it will also keep the position of the last played song.
<img width="402" alt="Screenshot 2024-09-11 at 22 33 15" src="https://github.com/user-attachments/assets/c2c2f80a-2dd1-4e15-a746-544db5d3360d">

------------

After merging this PR, the media player cards will have the following appearance 
<img width="402" alt="Screenshot 2024-09-11 at 22 30 48" src="https://github.com/user-attachments/assets/16e3dcf7-1f56-4bc9-9d26-c7a674e89f1b">

The Sonos integration takes the [same approach](https://github.com/home-assistant/core/blob/610e9239a4397febf8bf192225a2d23629ff6c0a/homeassistant/components/sonos/media_player.py#L343-L346).

Relates to #20 

