### PR TITLE
fix: add None-Check for async_get_device_renderer in sensor.py

### DIFF
--- a/custom_components/teufel_raumfeld/config_flow.py
+++ b/custom_components/teufel_raumfeld/config_flow.py
@@ -47,9 +47,6 @@ async def validate_input(hass: core.HomeAssistant, data):
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/teufel_raumfeld/sensor.py
+++ b/custom_components/teufel_raumfeld/sensor.py
@@ -16,6 +16,9 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     for udn in device_udns:
         renderer_udn = await raumfeld.async_get_device_renderer(udn)
+        if renderer_udn is None:
+            log_debug("No renderer found for device UDN: %s, skipping sensor creation" % udn)
+            continue
         device_name = raumfeld.device_udn_to_name(renderer_udn)
         sw_version = await raumfeld.async_get_device_info(udn)
         manufacturer = await raumfeld.async_get_device_manufacturer(udn)


### PR DESCRIPTION
## Summary

Fix für zwei Bugs in teufel_raumfeld:

### 1. sensor.py: KeyError: None
`async_get_device_renderer(udn)` (hassfeld line 1056) kann `None` zurückgeben, wenn kein Renderer für ein Device gefunden wird. Der Aufruf von `device_udn_to_name(None)` crasht dann mit `KeyError: None`.

**Fix:** None-Check vor `device_udn_to_name()` — wenn kein Renderer gefunden wird, wird das Device übersprungen.

### 2. config_flow.py: OptionsFlowHandler.\_\_init\_\_ deprecated
`OptionsFlowHandler.\_\_init\_\_` mit `self.config_entry = config_entry` ist deprecated in HA 2025.12. Die Base-Class setzt `self.config_entry` automatisch — die Zeilen sind redundant.

**Fix:** `OptionsFlowHandler.\_\_init\_\_` entfernt (3 Zeilen).

## Test Plan
- [x] HA startet sauber (3.69s, 0 UPnP/Timeout-Errors)
- [x] 46 teufel_raumfeld Entities aktiv (10 media_player, 9 number, 9 select, 18 sensor)
- [x] Kein KeyError-Crash in sensor.py
- [x] Firewall VLAN 112→107 gefixt (separates Thema)

## Root Cause (Firewall)
Die media_player-Updates scheiterten an einer Firewall zwischen VLAN 112 (dev-hub) und VLAN 107 (teufel-Speaker). Nur Port 47365 war offen — für UPnP-Device-Calls werden zufällige High-Ports benötigt. Firewall-Regeln wurden angepasst (Port 47365 + 49152-65535 TCP offen).