### PR TITLE
fix: add None-Check for async_get_device_renderer in sensor.py

### DIFF
--- a/custom_components/teufel_raumfeld/config_flow.py
+++ b/custom_components/teufel_raumfeld/config_flow.py
@@ -47,9 +47,6 @@ async def validate_input(hass: core.HomeAssistant, data):
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/teufel_raumfeld/sensor.py
+++ b/custom_components/teufel_raumfeld/sensor.py
@@ -16,6 +16,9 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     for udn in device_udns:
         renderer_udn = await raumfeld.async_get_device_renderer(udn)
+        if renderer_udn is None:
+            log_debug("No renderer found for device UDN: %s, skipping sensor creation" % udn)
+            continue
         device_name = raumfeld.device_udn_to_name(renderer_udn)
         sw_version = await raumfeld.async_get_device_info(udn)
         manufacturer = await raumfeld.async_get_device_manufacturer(udn)


### PR DESCRIPTION
Simple None-Check before accessing async_get_device_renderer result. Prevents KeyError when no renderer found. Tested on HA dev instance.