### PR TITLE
fix: chr(38) → & in README.md — Python string concat removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then restart Home Assistant.
 
 After installation:
 
-1. **Settings → Devices ' + chr(38) + ' Services → Add Integration**
+1. **Settings → Devices & Services → Add Integration**
 2. Select **Teufel Raumfeld**
 3. Enter the hostname/IP of your Raumfeld host (default port: 47365)
 4. The integration auto-discovers rooms and groups


### PR DESCRIPTION
## Summary

Fixes a Python string concatenation leak in the English README:

```diff
-**Settings → Devices ' + chr(38) + ' Services → Add Integration**
+**Settings → Devices & Services → Add Integration**
```

The `chr(38)` was Python code that should have been the literal `&` ampersand character — likely a copy-paste artifact from a Python f-string.