### PR TITLE
fix: include README.md in release zip for HACS info display

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ jobs:
 
       - name: Build release zip
         run: |
+          cp README.md custom_components/teufel_raumfeld/
           cd custom_components/teufel_raumfeld
           zip -r ../../teufel_raumfeld.zip . \
             -x "__pycache__/*" "*.pyc"


### PR DESCRIPTION
## Root Cause

HACS shows "no information" because the release zip (teufel_raumfeld.zip) does not contain README.md.

HACS with `zip_release: true` and `render_readme: true` in hacs.json:
1. Downloads the release zip
2. Extracts it
3. Scans for README variants (README.md, readme.md, etc.)
4. Found none → shows "no information"

## Fix

Copy `README.md` into `custom_components/teufel_raumfeld/` before zipping in the release workflow. This ensures the README is included in the release artifact and discoverable by HACS.

## Test Plan

- Next release will include README.md in the zip
- HACS should then display the README content instead of "no information"

Related: #85 (previous README fixes)