### PR TITLE
feat: expand CI with tests, lint, type-check; add 62 new tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev --extra ha
+      - run: uv run ruff check custom_components/ tests/
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev --extra ha
+      - run: uv run mypy custom_components/
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --group dev --extra ha
+      - run: uv run pytest tests/ -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,4 +33,5 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --group dev --extra ha
+      - run: uv pip install -e .
       - run: uv run pytest tests/ -v

--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,4 +1,4 @@
-name: "HACS validation"
+name: HACS validation
 
 on:
   push:
@@ -9,10 +9,10 @@ on:
 
 jobs:
   validate-hacs:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: actions/checkout@v4
       - name: HACS validation
-        uses: "hacs/action@main"
+        uses: hacs/action@main
         with:
-          category: "integration"
+          category: integration

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   validate:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: actions/checkout@v4
       - uses: home-assistant/actions/hassfest@master

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,130 @@
+"""Tests for teufel_raumfeld config_flow module."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.teufel_raumfeld.const import (
+    OPTION_ANNOUNCEMENT_VOLUME,
+    OPTION_CHANGE_STEP_VOLUME_DOWN,
+    OPTION_CHANGE_STEP_VOLUME_UP,
+    OPTION_DEFAULT_VOLUME,
+    OPTION_FIXED_ANNOUNCEMENT_VOLUME,
+    OPTION_USE_DEFAULT_VOLUME,
+)
+
+
+class TestOptionsFlowHandler:
+    """Tests for the OptionsFlowHandler options form."""
+
+    @pytest.mark.asyncio
+    async def test_submit_creates_entry(self):
+        """Submitting the options form creates an options entry."""
+        from custom_components.teufel_raumfeld.config_flow import OptionsFlowHandler
+
+        config_entry = MagicMock()
+        config_entry.options.get.side_effect = lambda key, default: default
+
+        handler = OptionsFlowHandler(config_entry)
+        # config_entry is a @property that reads from self.handler.config_entry.
+        # Mock handler (which would be set by the framework).
+        handler.handler = MagicMock()
+        handler.handler.config_entry = config_entry
+        handler.hass = MagicMock()
+
+        user_input = {
+            OPTION_FIXED_ANNOUNCEMENT_VOLUME: True,
+            OPTION_ANNOUNCEMENT_VOLUME: 50,
+            OPTION_USE_DEFAULT_VOLUME: False,
+            OPTION_DEFAULT_VOLUME: 30,
+            OPTION_CHANGE_STEP_VOLUME_UP: 3,
+            OPTION_CHANGE_STEP_VOLUME_DOWN: 2,
+        }
+
+        result = await handler.async_step_init(user_input=user_input)
+        assert result["type"] == "create_entry"
+        assert result["data"] == user_input
+
+
+class TestConfigFlowUserStep:
+    """Tests for the ConfigFlow async_step_user method."""
+
+    @pytest.mark.asyncio
+    async def test_show_form_when_no_input(self):
+        from custom_components.teufel_raumfeld.config_flow import ConfigFlow
+
+        flow = ConfigFlow()
+        flow.hass = MagicMock()
+
+        result = await flow.async_step_user(user_input=None)
+        assert result["type"] == "form"
+
+    @pytest.mark.asyncio
+    async def test_successful_validation_creates_entry(self):
+        from custom_components.teufel_raumfeld.config_flow import ConfigFlow
+
+        flow = ConfigFlow()
+        flow.hass = MagicMock()
+
+        with patch(
+            "custom_components.teufel_raumfeld.config_flow.validate_input",
+            new_callable=AsyncMock,
+        ) as mock_validate:
+            mock_validate.return_value = {"title": "Raumfeld host: 192.168.1.100"}
+
+            result = await flow.async_step_user(
+                user_input={"host": "192.168.1.100", "port": "47365"}
+            )
+            assert result["type"] == "create_entry"
+            assert result["title"] == "Raumfeld host: 192.168.1.100"
+            assert result["data"]["host"] == "192.168.1.100"
+
+    @pytest.mark.asyncio
+    async def test_cannot_connect_shows_error(self):
+        from custom_components.teufel_raumfeld.config_flow import (
+            CannotConnect,
+            ConfigFlow,
+        )
+
+        flow = ConfigFlow()
+        flow.hass = MagicMock()
+
+        with patch(
+            "custom_components.teufel_raumfeld.config_flow.validate_input",
+            new_callable=AsyncMock,
+        ) as mock_validate:
+            mock_validate.side_effect = CannotConnect
+
+            result = await flow.async_step_user(
+                user_input={"host": "bad-host", "port": "47365"}
+            )
+            assert result["type"] == "form"
+            assert result["errors"]["base"] == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_shows_unknown(self):
+        from custom_components.teufel_raumfeld.config_flow import ConfigFlow
+
+        flow = ConfigFlow()
+        flow.hass = MagicMock()
+
+        with patch(
+            "custom_components.teufel_raumfeld.config_flow.validate_input",
+            new_callable=AsyncMock,
+        ) as mock_validate:
+            mock_validate.side_effect = RuntimeError("Boom")
+
+            result = await flow.async_step_user(
+                user_input={"host": "bad-host", "port": "47365"}
+            )
+            assert result["type"] == "form"
+            assert result["errors"]["base"] == "unknown"
+
+    def test_form_schema_has_host_and_port(self):
+        from custom_components.teufel_raumfeld.config_flow import (
+            STEP_USER_DATA_SCHEMA,
+        )
+
+        schema_str = str(STEP_USER_DATA_SCHEMA.schema)
+        assert "host" in schema_str
+        assert "port" in schema_str

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,237 @@
+"""Tests for teufel_raumfeld __init__ module — utility functions and HassRaumfeldHost."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.teufel_raumfeld.__init__ import (
+    HassRaumfeldHost,
+    is_supported_oid,
+    timespan_secs,
+)
+from custom_components.teufel_raumfeld.const import (
+    MEDIA_CONTENT_ID_SEP,
+    OBJECT_ID_LINE_IN,
+    PORT_LINE_IN,
+    TITLE_UNKNOWN,
+    UPNP_CLASS_ALBUM,
+    UPNP_CLASS_AUDIO_ITEM,
+    UPNP_CLASS_LINE_IN,
+    UPNP_CLASS_PLAYLIST_CONTAINER,
+    UPNP_CLASS_PODCAST_EPISODE,
+    UPNP_CLASS_RADIO,
+    UPNP_CLASS_TRACK,
+)
+
+
+class TestTimespanSecs:
+    """Tests for timespan_secs — parsing H:MM:SS / MM:SS / SS strings."""
+
+    def test_full_hms(self):
+        assert timespan_secs("1:02:03") == 3723
+
+    def test_minutes_seconds(self):
+        assert timespan_secs("05:30") == 330
+
+    def test_seconds_only(self):
+        assert timespan_secs("42") == 42
+
+    def test_zero(self):
+        assert timespan_secs("0:00:00") == 0
+
+    def test_leading_zeroes(self):
+        assert timespan_secs("00:01:05") == 65
+
+
+class TestIsSupportedOid:
+    """Tests for is_supported_oid."""
+
+    def test_normal_oid(self):
+        assert is_supported_oid("0/My Music/Albums") is True
+
+    def test_unsupported_search_oid(self):
+        assert is_supported_oid("0/My Music/Search") is False
+
+    def test_unsupported_spotify_oid(self):
+        assert is_supported_oid("0/Spotify") is False
+
+    def test_unsupported_zones_oid(self):
+        assert is_supported_oid("0/Zones") is False
+
+    def test_unsupported_renderers_oid(self):
+        assert is_supported_oid("0/Renderers") is False
+
+    def test_unsupported_shuffles_oid(self):
+        assert is_supported_oid("0/Playlists/Shuffles") is False
+
+    def test_unsupported_tidal_search(self):
+        assert is_supported_oid("0/Tidal/Search") is False
+
+    def test_unsupported_radiotime_search(self):
+        assert is_supported_oid("0/RadioTime/Search") is False
+
+
+class TestMkPlayUri:
+    """Tests for HassRaumfeldHost.mk_play_uri — synchronous, needs mock session."""
+
+    def setup_method(self):
+        mock_session = MagicMock()
+        self.host = HassRaumfeldHost(host="127.0.0.1", session=mock_session)
+        self.host.media_server_udn = "uuid:test-ms-udn"
+
+    def test_album_uri(self):
+        uri = self.host.mk_play_uri(
+            self.host.media_server_udn, UPNP_CLASS_ALBUM, "0/My Music/Albums/Test"
+        )
+        assert uri is not None
+        assert uri.startswith("dlna-playcontainer://")
+
+    def test_playlist_container_uri(self):
+        uri = self.host.mk_play_uri(
+            self.host.media_server_udn,
+            UPNP_CLASS_PLAYLIST_CONTAINER,
+            "0/Playlists/MyList",
+        )
+        assert uri is not None
+        assert uri.startswith("dlna-playcontainer://")
+
+    def test_track_uri_has_fid(self):
+        uri = self.host.mk_play_uri(
+            self.host.media_server_udn, UPNP_CLASS_TRACK, "0/My Music/Albums/Test/1.mp3"
+        )
+        assert "&fid=" in uri
+
+    def test_podcast_episode_has_fid(self):
+        uri = self.host.mk_play_uri(
+            self.host.media_server_udn,
+            UPNP_CLASS_PODCAST_EPISODE,
+            "0/Podcasts/Show/Episode1",
+        )
+        assert "&fid=" in uri
+
+    def test_radio_uri(self):
+        uri = self.host.mk_play_uri(
+            self.host.media_server_udn, UPNP_CLASS_RADIO, "0/RadioTime/Stations/WDR2"
+        )
+        assert uri.startswith("dlna-playsingle://")
+        assert "&iid=" in uri
+
+    def test_line_in_uri(self):
+        encoded_udn = "uuid%3Atest-device-udn"
+        oid = f"{OBJECT_ID_LINE_IN}/{encoded_udn}"
+        self.host.device_udn_to_location = MagicMock(return_value="http://10.0.0.5:47365")
+        uri = self.host.mk_play_uri(self.host.media_server_udn, UPNP_CLASS_LINE_IN, oid)
+        assert uri is not None
+        assert f":{PORT_LINE_IN}/stream.flac" in uri
+
+    def test_line_in_non_matching_oid_returns_none(self):
+        self.host.device_udn_to_location = MagicMock()
+        uri = self.host.mk_play_uri(
+            self.host.media_server_udn, UPNP_CLASS_LINE_IN, "0/SomeOther"
+        )
+        assert uri is None
+
+    def test_audio_item_fallback(self):
+        uri = self.host.mk_play_uri(
+            self.host.media_server_udn, UPNP_CLASS_AUDIO_ITEM, "some_id"
+        )
+        assert uri == "some_id"
+
+    def test_album_uri_correct_params(self):
+        uri = self.host.mk_play_uri(
+            self.host.media_server_udn, UPNP_CLASS_ALBUM, "0/Albums/5"
+        )
+        assert "?sid=" in uri
+        assert "&cid=" in uri
+        assert "&md=0" in uri
+
+
+class TestAsyncBrowseMedia:
+    """Tests for HassRaumfeldHost.async_browse_media."""
+
+    def setup_method(self):
+        mock_session = MagicMock()
+        self.host = HassRaumfeldHost(host="127.0.0.1", session=mock_session)
+
+    @pytest.mark.asyncio
+    async def test_empty_when_none(self):
+        self.host.async_browse_media_server = AsyncMock(return_value=None)
+        result = await self.host.async_browse_media(object_id="0")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_separator_stripped(self):
+        self.host.async_browse_media_server = AsyncMock(return_value=None)
+        await self.host.async_browse_media(
+            object_id=f"0/My Music{MEDIA_CONTENT_ID_SEP}dlna-playsingle://..."
+        )
+        called_oid = self.host.async_browse_media_server.call_args[0][0]
+        assert called_oid == "0/My Music"
+
+    @pytest.mark.asyncio
+    async def test_containers_and_items(self):
+        didl_xml = (
+            '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"'
+            ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+            '<container id="0/My Music" childCount="5" restricted="1">'
+            "<dc:title>My Music</dc:title>"
+            '<upnp:class>object.container.storageFolder</upnp:class>'
+            "</container>"
+            '<item id="0/My Music/Track1.mp3" restricted="1">'
+            "<dc:title>Test Track</dc:title>"
+            '<upnp:class>object.item.audioItem.musicTrack</upnp:class>'
+            "</item>"
+            "</DIDL-Lite>"
+        )
+        self.host.async_browse_media_server = AsyncMock(return_value=didl_xml)
+        self.host.media_server_udn = "uuid:test"
+        self.host.mk_play_uri = MagicMock(return_value="dlna-playcontainer://test")
+
+        result = await self.host.async_browse_media(object_id="0")
+
+        assert len(result) == 2
+        assert result[0].title == "My Music"
+        assert result[0].can_expand is True
+        assert result[1].title == "Test Track"
+        assert result[1].can_expand is False
+
+    @pytest.mark.asyncio
+    async def test_skips_unsupported_oids(self):
+        didl_xml = (
+            '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"'
+            ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+            '<container id="0/My Music/Search" childCount="0" restricted="1">'
+            "<dc:title>Search</dc:title>"
+            '<upnp:class>object.container</upnp:class>'
+            "</container>"
+            '<item id="0/My Music/Track1.mp3" restricted="1">'
+            "<dc:title>Valid Track</dc:title>"
+            '<upnp:class>object.item.audioItem.musicTrack</upnp:class>'
+            "</item>"
+            "</DIDL-Lite>"
+        )
+        self.host.async_browse_media_server = AsyncMock(return_value=didl_xml)
+        self.host.media_server_udn = "uuid:test"
+        self.host.mk_play_uri = MagicMock(return_value="dlna-playsingle://test")
+
+        result = await self.host.async_browse_media(object_id="0")
+        assert len(result) == 1
+        assert result[0].title == "Valid Track"
+
+    @pytest.mark.asyncio
+    async def test_entry_without_title(self):
+        didl_xml = (
+            '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"'
+            ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+            '<container id="0/My Music" childCount="5" restricted="1">'
+            '<upnp:class>object.container.storageFolder</upnp:class>'
+            "</container>"
+            "</DIDL-Lite>"
+        )
+        self.host.async_browse_media_server = AsyncMock(return_value=didl_xml)
+        self.host.media_server_udn = "uuid:test"
+        self.host.mk_play_uri = MagicMock(return_value="dlna-playsingle://test")
+
+        result = await self.host.async_browse_media(object_id="0")
+        assert len(result) == 1
+        assert result[0].title == TITLE_UNKNOWN

--- a/tests/test_media_player_entity.py
+++ b/tests/test_media_player_entity.py
@@ -1,0 +1,309 @@
+"""Tests for RaumfeldGroup and RaumfeldRoom media player entities."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.teufel_raumfeld.const import (
+    OPTION_CHANGE_STEP_VOLUME_DOWN,
+    OPTION_CHANGE_STEP_VOLUME_UP,
+)
+from custom_components.teufel_raumfeld.media_player import (
+    SUPPORT_RAUMFELD_GROUP,
+    SUPPORT_RAUMFELD_ROOM,
+    RaumfeldGroup,
+    RaumfeldRoom,
+)
+
+
+class TestRaumfeldGroupCore:
+    """Tests for RaumfeldGroup basic properties and initialization."""
+
+    def setup_method(self):
+        self.rooms = ["Wohnzimmer", "Küche"]
+        self.raumfeld = MagicMock()
+        self.raumfeld.options = {}
+        self.group = RaumfeldGroup(self.rooms, self.raumfeld)
+
+    def test_name_prefixed_with_group(self):
+        assert self.group.name.startswith("Group: ")
+
+    def test_unique_id_is_stable(self):
+        uid = self.group.unique_id
+        assert uid.startswith("v2:")
+
+    def test_device_class_is_speaker(self):
+        assert self.group.device_class == "speaker"
+
+    def test_icon_is_multiple_speakers(self):
+        assert "multiple" in self.group.icon
+
+    def test_supported_features(self):
+        assert self.group.supported_features == SUPPORT_RAUMFELD_GROUP
+
+    def test_group_members_returns_rooms(self):
+        assert self.group.group_members == self.rooms
+
+    def test_state_defaults_none(self):
+        assert self.group.state is None
+
+
+class TestRaumfeldGroupVolume:
+    """Tests for volume-related methods, mocking update chain."""
+
+    def setup_method(self):
+        self.rooms = ["Wohnzimmer"]
+        self.raumfeld = MagicMock()
+        self.raumfeld.options = {
+            OPTION_CHANGE_STEP_VOLUME_UP: 5,
+            OPTION_CHANGE_STEP_VOLUME_DOWN: 2,
+        }
+        self.group = RaumfeldGroup(self.rooms, self.raumfeld)
+
+    @pytest.mark.asyncio
+    async def test_volume_up_calls_change_group_volume(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_change_group_volume = AsyncMock()
+        self.group.async_update_volume_level = AsyncMock()
+
+        await self.group.async_volume_up()
+
+        self.raumfeld.async_change_group_volume.assert_called_once_with(
+            self.rooms, 5
+        )
+
+    @pytest.mark.asyncio
+    async def test_volume_down_calls_change_group_volume(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_change_group_volume = AsyncMock()
+        self.group.async_update_volume_level = AsyncMock()
+
+        await self.group.async_volume_down()
+
+        self.raumfeld.async_change_group_volume.assert_called_once_with(
+            self.rooms, -2
+        )
+
+    @pytest.mark.asyncio
+    async def test_volume_up_invalid_group_logs(self):
+        self.raumfeld.group_is_valid.return_value = False
+
+        await self.group.async_volume_up()
+        # Should not crash, just log debug
+
+    @pytest.mark.asyncio
+    async def test_set_volume_level(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_set_group_volume = AsyncMock()
+        self.group.async_update_volume_level = AsyncMock()
+
+        await self.group.async_set_volume_level(0.75)
+
+        self.raumfeld.async_set_group_volume.assert_called_once_with(
+            self.rooms, 75
+        )
+
+
+class TestRaumfeldGroupMute:
+    """Tests for mute-related methods."""
+
+    def setup_method(self):
+        self.rooms = ["Wohnzimmer"]
+        self.raumfeld = MagicMock()
+        self.raumfeld.options = {}
+        self.group = RaumfeldGroup(self.rooms, self.raumfeld)
+
+    @pytest.mark.asyncio
+    async def test_mute_true(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_set_group_mute = AsyncMock()
+        self.group.async_update_mute = AsyncMock()
+
+        await self.group.async_mute_volume(True)
+
+        self.raumfeld.async_set_group_mute.assert_called_once_with(
+            self.rooms, True
+        )
+
+    @pytest.mark.asyncio
+    async def test_mute_false(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_set_group_mute = AsyncMock()
+        self.group.async_update_mute = AsyncMock()
+
+        await self.group.async_mute_volume(False)
+
+        self.raumfeld.async_set_group_mute.assert_called_once_with(
+            self.rooms, False
+        )
+
+
+class TestRaumfeldGroupTransport:
+    """Tests for transport control methods."""
+
+    def setup_method(self):
+        self.rooms = ["Wohnzimmer"]
+        self.raumfeld = MagicMock()
+        self.raumfeld.options = {}
+        self.group = RaumfeldGroup(self.rooms, self.raumfeld)
+
+    @pytest.mark.asyncio
+    async def test_media_play(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_group_play = AsyncMock()
+        self.group.async_update_transport_state = AsyncMock()
+
+        await self.group.async_media_play()
+        self.raumfeld.async_group_play.assert_called_once_with(self.rooms)
+
+    @pytest.mark.asyncio
+    async def test_media_pause(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_group_pause = AsyncMock()
+        self.group.async_update_transport_state = AsyncMock()
+
+        await self.group.async_media_pause()
+        self.raumfeld.async_group_pause.assert_called_once_with(self.rooms)
+
+    @pytest.mark.asyncio
+    async def test_media_stop(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_group_stop = AsyncMock()
+        self.group.async_update_transport_state = AsyncMock()
+
+        await self.group.async_media_stop()
+        self.raumfeld.async_group_stop.assert_called_once_with(self.rooms)
+
+    @pytest.mark.asyncio
+    async def test_media_previous_track(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_group_previous_track = AsyncMock()
+        self.group.async_update_track_info = AsyncMock()
+
+        await self.group.async_media_previous_track()
+        self.raumfeld.async_group_previous_track.assert_called_once_with(self.rooms)
+
+    @pytest.mark.asyncio
+    async def test_media_next_track(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_group_next_track = AsyncMock()
+        self.group.async_update_track_info = AsyncMock()
+
+        await self.group.async_media_next_track()
+        self.raumfeld.async_group_next_track.assert_called_once_with(self.rooms)
+
+    @pytest.mark.asyncio
+    async def test_media_seek(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_group_seek = AsyncMock()
+        self.group.async_update_track_info = AsyncMock()
+
+        await self.group.async_media_seek(120)
+        self.raumfeld.async_group_seek.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_group_no_crash(self):
+        """Methods called on invalid group should log debug, not crash."""
+        self.raumfeld.group_is_valid.return_value = False
+        self.group.async_update_transport_state = AsyncMock()
+        self.group.async_update_track_info = AsyncMock()
+
+        await self.group.async_media_play()
+        await self.group.async_media_pause()
+        await self.group.async_media_stop()
+        await self.group.async_media_previous_track()
+        await self.group.async_media_next_track()
+        await self.group.async_media_seek(120)
+        # None of these should raise
+
+
+class TestRaumfeldGroupSnapshot:
+    """Tests for snapshot/restore methods."""
+
+    def setup_method(self):
+        self.rooms = ["Wohnzimmer"]
+        self.raumfeld = MagicMock()
+        self.raumfeld.options = {}
+        self.group = RaumfeldGroup(self.rooms, self.raumfeld)
+
+    @pytest.mark.asyncio
+    async def test_snapshot(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_save_group = AsyncMock()
+
+        await self.group.async_snapshot()
+
+        self.raumfeld.async_save_group.assert_called_once_with(self.rooms)
+
+    @pytest.mark.asyncio
+    async def test_restore(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_restore_group = AsyncMock()
+
+        await self.group.async_restore()
+
+        self.raumfeld.async_restore_group.assert_called_once_with(self.rooms)
+
+
+class TestRaumfeldRoom:
+    """Tests for RaumfeldRoom (single-room media player)."""
+
+    def setup_method(self):
+        self.room = "Wohnzimmer"
+        self.raumfeld = MagicMock()
+        self.raumfeld.options = {}
+        self.room_entity = RaumfeldRoom(self.room, self.raumfeld)
+
+    def test_name_prefixed_with_room(self):
+        assert self.room_entity.name.startswith("Room: ")
+
+    def test_icon_is_single_speaker(self):
+        assert self.room_entity.icon == "mdi:speaker"
+
+    def test_supported_features_includes_grouping(self):
+        assert self.room_entity.supported_features == SUPPORT_RAUMFELD_ROOM
+
+    def test_group_members_returns_single_room(self):
+        assert self.room_entity.group_members == [self.room]
+
+    @pytest.mark.asyncio
+    async def test_unjoin_player_valid(self):
+        """Unjoining a player when group is invalid (= standalone room)."""
+        self.raumfeld.group_is_valid.return_value = False
+        self.raumfeld.async_drop_room_from_group = AsyncMock()
+        self.room_entity.async_update_transport_state = AsyncMock()
+
+        await self.room_entity.async_unjoin_player()
+        self.raumfeld.async_drop_room_from_group.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_join_players(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.eid_to_obj = {"media_player.kueche": ["Küche"]}
+        self.raumfeld.async_add_rooms_to_group = AsyncMock()
+        self.room_entity.async_update_transport_state = AsyncMock()
+
+        await self.room_entity.async_join_players(["media_player.kueche"])
+        self.raumfeld.async_add_rooms_to_group.assert_called_once()
+
+
+class TestPlaySystemSound:
+    """Tests for the play_system_sound service method."""
+
+    def setup_method(self):
+        self.rooms = ["Wohnzimmer", "Küche"]
+        self.raumfeld = MagicMock()
+        self.raumfeld.options = {}
+        self.group = RaumfeldGroup(self.rooms, self.raumfeld)
+
+    @pytest.mark.asyncio
+    async def test_play_system_sound_on_all_rooms(self):
+        self.raumfeld.group_is_valid.return_value = True
+        self.raumfeld.async_room_play_system_sound = AsyncMock()
+
+        await self.group.async_play_system_sound(sound="Success")
+
+        assert self.raumfeld.async_room_play_system_sound.call_count == 2
+        calls = self.raumfeld.async_room_play_system_sound.call_args_list
+        assert calls[0][0] == ("Wohnzimmer", "Success")
+        assert calls[1][0] == ("Küche", "Success")


### PR DESCRIPTION
## Summary

- **CI pipeline** (`ci.yaml`): ruff lint, mypy type-check, pytest (3 jobs, Python 3.13)
- **Bump** `checkout@v3` to `v4` in hassfest.yaml, hacs.yaml
- **Fix** `pyproject.toml` version mismatch (0.1.16 to 0.1.17-alpha1)
- **New tests** (19 to 81): `test_init.py` (31), `test_config_flow.py` (6), `test_media_player_entity.py` (24)

Coverage now includes: `timespan_secs`, `is_supported_oid`, `mk_play_uri` (all media types), `async_browse_media` (DIDL-Lite parsing, namespaces, unsupported OIDs), ConfigFlow (form, errors), RaumfeldGroup/Room (volume, mute, transport, snapshot, system sounds).

## Notes
- CI lint job will fail initially - 65 pre-existing ruff issues in source code. Not introduced by this PR.
- CI type-check uses `ignore_missing_imports = true`. 286 mypy errors remain from `strict = true`.