### PR TITLE
docs: remove custom-repo step from README (repo is in HACS defaults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,12 @@ Supported platforms: `media_player`, `sensor`, `select`, `number`
 ### HACS (recommended)
 
 1. Make sure [HACS](https://hacs.xyz/) is installed
-2. HACS → Integrations → Three-dot menu → **Custom repositories**
-3. Add `https://github.com/B5r1oJ0A9G/teufel_raumfeld`, category: **Integration**
-4. Search for **Teufel Raumfeld** and install
-5. Restart Home Assistant
+2. HACS → Integrations → Search for **Teufel Raumfeld** and install
+3. Restart Home Assistant
 
 ### Manual
 
-```bash
-cd /config/custom_components
-git clone https://github.com/B5r1oJ0A9G/teufel_raumfeld.git teufel_raumfeld
-```
+Download the [latest release](https://github.com/B5r1oJ0A9G/teufel_raumfeld/releases/latest) and extract it to `/config/custom_components/teufel_raumfeld/`.
 
 Then restart Home Assistant.
 


### PR DESCRIPTION
Confirmed via HACS data-v2 index (id=334523683). The integration is listed in the default HACS repositories — users can search and install directly, no custom repository setup needed.

Also simplified manual install: download latest release zip instead of git clone.