### PR TITLE
fix(ci): native gh release upload instead of softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,6 @@ jobs:
             -x "__pycache__/*" "*.pyc"
 
       - name: Upload zip to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: teufel_raumfeld.zip
+        run: gh release upload ${{ github.ref_name }} teufel_raumfeld.zip
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Replaces `softprops/action-gh-release@v2` with native `gh release upload`.

**Why:** `softprops/action-gh-release@v2` runs on Node.js 20 and generates deprecation warnings. The `gh` CLI is pre-installed on every GitHub runner and maintained by GitHub — no external action, no Node dependency, no warnings.

**Change:**
```diff
-        uses: softprops/action-gh-release@v2
-        with:
-          files: teufel_raumfeld.zip
+        run: gh release upload ${{ github.ref_name }} teufel_raumfeld.zip
+        env:
+          GH_TOKEN: ${{ github.token }}
```
