### PR TITLE
feat(ci): add ruff format, TD lint rules, and pre-commit config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --group dev --extra ha
+      - run: uv run ruff format --check custom_components/ tests/
       - run: uv run ruff check custom_components/ tests/
 
   type-check:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.14
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format

--- a/custom_components/teufel_raumfeld/__init__.py
+++ b/custom_components/teufel_raumfeld/__init__.py
@@ -1,4 +1,5 @@
 """The Teufel Raumfeld integration."""
+
 import asyncio
 import inspect
 import logging
@@ -92,9 +93,7 @@ def set_hassfeld_log_level(raumfeld):
     else:
         hassfeld_level = logging.CRITICAL
 
-    log_info(
-        f"Setting logging level of hassfeld to: {logging.getLevelName(hassfeld_level)}"
-    )
+    log_info(f"Setting logging level of hassfeld to: {logging.getLevelName(hassfeld_level)}")
     raumfeld.set_logging_level(hassfeld_level)
 
 
@@ -151,17 +150,11 @@ def event_on_update(hass, update_type):
     """fires events on Raumfeld web service updates."""
     log_info(f"Update event triggered for type: {update_type}")
     if update_type == TRIGGER_UPDATE_HOST_INFO:
-        hass.bus.fire(
-            EVENT_WEBSERVICE_UPDATE, {ATTR_EVENT_WSUPD_TYPE: TRIGGER_UPDATE_HOST_INFO}
-        )
+        hass.bus.fire(EVENT_WEBSERVICE_UPDATE, {ATTR_EVENT_WSUPD_TYPE: TRIGGER_UPDATE_HOST_INFO})
     elif update_type == TRIGGER_UPDATE_ZONE_CONFIG:
-        hass.bus.fire(
-            EVENT_WEBSERVICE_UPDATE, {ATTR_EVENT_WSUPD_TYPE: TRIGGER_UPDATE_ZONE_CONFIG}
-        )
+        hass.bus.fire(EVENT_WEBSERVICE_UPDATE, {ATTR_EVENT_WSUPD_TYPE: TRIGGER_UPDATE_ZONE_CONFIG})
     elif update_type == TRIGGER_UPDATE_DEVICES:
-        hass.bus.fire(
-            EVENT_WEBSERVICE_UPDATE, {ATTR_EVENT_WSUPD_TYPE: TRIGGER_UPDATE_DEVICES}
-        )
+        hass.bus.fire(EVENT_WEBSERVICE_UPDATE, {ATTR_EVENT_WSUPD_TYPE: TRIGGER_UPDATE_DEVICES})
     elif update_type == TRIGGER_UPDATE_SYSTEM_STATE:
         hass.bus.fire(
             EVENT_WEBSERVICE_UPDATE,
@@ -188,18 +181,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     http_session = aiohttp_client.async_get_clientsession(hass)
     raumfeld = HassRaumfeldHost(host, port, session=http_session)
     set_hassfeld_log_level(raumfeld)
-    raumfeld.options[OPTION_ANNOUNCEMENT_VOLUME] = entry.options.get(
-        OPTION_ANNOUNCEMENT_VOLUME, DEFAULT_ANNOUNCEMENT_VOLUME
-    )
-    raumfeld.options[OPTION_FIXED_ANNOUNCEMENT_VOLUME] = entry.options.get(
-        OPTION_ANNOUNCEMENT_VOLUME, False
-    )
-    raumfeld.options[OPTION_DEFAULT_VOLUME] = entry.options.get(
-        OPTION_DEFAULT_VOLUME, DEFAULT_VOLUME
-    )
-    raumfeld.options[OPTION_USE_DEFAULT_VOLUME] = entry.options.get(
-        OPTION_USE_DEFAULT_VOLUME, False
-    )
+    raumfeld.options[OPTION_ANNOUNCEMENT_VOLUME] = entry.options.get(OPTION_ANNOUNCEMENT_VOLUME, DEFAULT_ANNOUNCEMENT_VOLUME)
+    raumfeld.options[OPTION_FIXED_ANNOUNCEMENT_VOLUME] = entry.options.get(OPTION_ANNOUNCEMENT_VOLUME, False)
+    raumfeld.options[OPTION_DEFAULT_VOLUME] = entry.options.get(OPTION_DEFAULT_VOLUME, DEFAULT_VOLUME)
+    raumfeld.options[OPTION_USE_DEFAULT_VOLUME] = entry.options.get(OPTION_USE_DEFAULT_VOLUME, False)
     raumfeld.options[OPTION_CHANGE_STEP_VOLUME_UP] = entry.options.get(
         OPTION_CHANGE_STEP_VOLUME_UP, DEFAULT_CHANGE_STEP_VOLUME_UP
     )
@@ -213,9 +198,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         host_is_not_valid = not await raumfeld.async_host_is_valid()
         if host_is_not_valid:
             await asyncio.sleep(DELAY_MODERATE_UPDATE_CHECKS)
-            log_info(
-                f"Starting attempt '{attempt + 1}' out of '{max_attempts}' attempts to identify host as valid"
-            )
+            log_info(f"Starting attempt '{attempt + 1}' out of '{max_attempts}' attempts to identify host as valid")
             continue
         break
     if host_is_not_valid:
@@ -267,9 +250,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.services.async_register(DOMAIN, SERVICE_GROUP, async_handle_group)
     hass.services.async_register(DOMAIN, SERVICE_ADD_ROOM, async_handle_add_room)
     hass.services.async_register(DOMAIN, SERVICE_DROP_ROOM, async_handle_drop_room)
-    hass.services.async_register(
-        DOMAIN, SERVICE_SET_ROOM_VOLUME, async_handle_set_room_volume
-    )
+    hass.services.async_register(DOMAIN, SERVICE_SET_ROOM_VOLUME, async_handle_set_room_volume)
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
@@ -279,12 +260,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
+        await asyncio.gather(*[hass.config_entries.async_forward_entry_unload(entry, component) for component in PLATFORMS])
     )
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
@@ -408,12 +384,7 @@ class HassRaumfeldHost(hassfeld.RaumfeldHost):
 
             if media_type in [UPNP_CLASS_TRACK, UPNP_CLASS_PODCAST_EPISODE]:
                 track_number = str(track_number)
-                play_uri += (
-                    "&fid="
-                    + urllib.parse.quote(media_id, safe="")
-                    + "&fii="
-                    + track_number
-                )
+                play_uri += "&fid=" + urllib.parse.quote(media_id, safe="") + "&fii=" + track_number
 
             return play_uri
         if media_type == UPNP_CLASS_RADIO:
@@ -436,14 +407,10 @@ class HassRaumfeldHost(hassfeld.RaumfeldHost):
                 uri_prefix = location.rsplit(":", 1)[0]
                 play_uri = f"{uri_prefix}:{PORT_LINE_IN}/stream.flac"
                 return play_uri
-            log_error(
-                f"Passed media_id '{media_id}' does not appear appropriate for media_type '{media_type}'"
-            )
+            log_error(f"Passed media_id '{media_id}' does not appear appropriate for media_type '{media_type}'")
             return None
 
-        log_info(
-            f"Building of playable URI for media type '{media_type}' not needed or not implemented"
-        )
+        log_info(f"Building of playable URI for media type '{media_type}' not needed or not implemented")
 
         return media_id
 
@@ -460,9 +427,7 @@ class HassRaumfeldHost(hassfeld.RaumfeldHost):
         if media_xml is None:
             return browse_lst
 
-        media = xmltodict.parse(
-            media_xml, force_list=(DIDL_ELEM_CONTAINER, DIDL_ELEM_ITEM)
-        )
+        media = xmltodict.parse(media_xml, force_list=(DIDL_ELEM_CONTAINER, DIDL_ELEM_ITEM))
 
         if DIDL_ELEM_CONTAINER in media[DIDL_ELEMENT]:
             media_entries += media[DIDL_ELEMENT][DIDL_ELEM_CONTAINER]
@@ -480,10 +445,7 @@ class HassRaumfeldHost(hassfeld.RaumfeldHost):
 
             # Workaround: Sometimes XML includes namespaces.
             if DIDL_ELEM_TITLE in entry:
-                if (
-                    entry[DIDL_ELEM_TITLE] is not None
-                    and DIDL_VALUE in entry[DIDL_ELEM_TITLE]
-                ):
+                if entry[DIDL_ELEM_TITLE] is not None and DIDL_VALUE in entry[DIDL_ELEM_TITLE]:
                     title = entry[DIDL_ELEM_TITLE][DIDL_VALUE]
                 else:
                     title = entry[DIDL_ELEM_TITLE]
@@ -549,24 +511,13 @@ class HassRaumfeldHost(hassfeld.RaumfeldHost):
             if metadata_xml is not None:
                 metadata = xmltodict.parse(metadata_xml)
                 if DIDL_ELEM_TITLE in metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM]:
-                    track_info[TRACKINF_TITLE] = metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM][
-                        DIDL_ELEM_TITLE
-                    ]
+                    track_info[TRACKINF_TITLE] = metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM][DIDL_ELEM_TITLE]
                 if DIDL_ELEM_ARTIST in metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM]:
-                    track_info[TRACKINF_ARTIST] = metadata[DIDL_ELEMENT][
-                        DIDL_ELEM_ITEM
-                    ][DIDL_ELEM_ARTIST]
+                    track_info[TRACKINF_ARTIST] = metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM][DIDL_ELEM_ARTIST]
                 if DIDL_ELEM_ART_URI in metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM]:
-                    if (
-                        DIDL_VALUE
-                        in metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM][DIDL_ELEM_ART_URI]
-                    ):
-                        track_info[TRACKINF_IMGURI] = metadata[DIDL_ELEMENT][
-                            DIDL_ELEM_ITEM
-                        ][DIDL_ELEM_ART_URI][DIDL_VALUE]
+                    if DIDL_VALUE in metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM][DIDL_ELEM_ART_URI]:
+                        track_info[TRACKINF_IMGURI] = metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM][DIDL_ELEM_ART_URI][DIDL_VALUE]
                 if DIDL_ELEM_ALBUM in metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM]:
-                    track_info[TRACKINF_ALBUM] = metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM][
-                        DIDL_ELEM_ALBUM
-                    ]
+                    track_info[TRACKINF_ALBUM] = metadata[DIDL_ELEMENT][DIDL_ELEM_ITEM][DIDL_ELEM_ALBUM]
 
             return track_info

--- a/custom_components/teufel_raumfeld/common.py
+++ b/custom_components/teufel_raumfeld/common.py
@@ -1,4 +1,5 @@
 """Commonly used classes."""
+
 import inspect
 
 from hassfeld.constants import (

--- a/custom_components/teufel_raumfeld/config_flow.py
+++ b/custom_components/teufel_raumfeld/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Teufel Raumfeld integration."""
+
 import logging
 from typing import Any
 
@@ -26,7 +27,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# TODO adjust the data schema to the data that you need
+# TODO(@B5r1oJ0A9G): Adjust the data schema to the data that you need.
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required("host", default=DEFAULT_HOST_WEBSERVICE): str,
@@ -52,9 +53,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         # config_entry is a property resolved after framework init via self.handler.
         # Accepted here so async_get_options_flow can pass it without TypeError.
 
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
@@ -65,27 +64,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Required(
                         OPTION_FIXED_ANNOUNCEMENT_VOLUME,
-                        default=self.config_entry.options.get(
-                            OPTION_FIXED_ANNOUNCEMENT_VOLUME, False
-                        ),
+                        default=self.config_entry.options.get(OPTION_FIXED_ANNOUNCEMENT_VOLUME, False),
                     ): bool,
                     vol.Required(
                         OPTION_ANNOUNCEMENT_VOLUME,
-                        default=self.config_entry.options.get(
-                            OPTION_ANNOUNCEMENT_VOLUME, DEFAULT_ANNOUNCEMENT_VOLUME
-                        ),
+                        default=self.config_entry.options.get(OPTION_ANNOUNCEMENT_VOLUME, DEFAULT_ANNOUNCEMENT_VOLUME),
                     ): vol.All(int, vol.Range(min=0, max=100)),
                     vol.Required(
                         OPTION_USE_DEFAULT_VOLUME,
-                        default=self.config_entry.options.get(
-                            OPTION_USE_DEFAULT_VOLUME, False
-                        ),
+                        default=self.config_entry.options.get(OPTION_USE_DEFAULT_VOLUME, False),
                     ): bool,
                     vol.Required(
                         OPTION_DEFAULT_VOLUME,
-                        default=self.config_entry.options.get(
-                            OPTION_DEFAULT_VOLUME, DEFAULT_VOLUME
-                        ),
+                        default=self.config_entry.options.get(OPTION_DEFAULT_VOLUME, DEFAULT_VOLUME),
                     ): vol.All(int, vol.Range(min=0, max=100)),
                     vol.Required(
                         OPTION_CHANGE_STEP_VOLUME_UP,
@@ -110,7 +101,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow to add Raumfeld media players and sensors."""
 
     VERSION = 1
-    # TODO pick one of the available connection classes in homeassistant/config_entries.py
+    # TODO(@B5r1oJ0A9G): Pick one of the available connection classes in homeassistant/config_entries.py.
     CONNECTION_CLASS = config_entries.CONN_CLASS_UNKNOWN
 
     @staticmethod
@@ -124,9 +115,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
-            )
+            return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA)
 
         errors = {}
 
@@ -142,9 +131,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data["entry_id"] = "raumfeld_host"
             return self.async_create_entry(title=info["title"], data=data)
 
-        return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
-        )
+        return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors)
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/custom_components/teufel_raumfeld/const.py
+++ b/custom_components/teufel_raumfeld/const.py
@@ -1,4 +1,5 @@
 """Constants for the Teufel Raumfeld integration."""
+
 VERSION = "0.1.17-alpha1"
 
 ATTR_EVENT_WSUPD_TYPE = "type"

--- a/custom_components/teufel_raumfeld/media_player.py
+++ b/custom_components/teufel_raumfeld/media_player.py
@@ -1,4 +1,5 @@
 """The Teufel Raumfeld media_player component."""
+
 import asyncio
 import base64
 import datetime
@@ -109,6 +110,7 @@ _LOGGER = logging.getLogger(__name__)
 
 UID_PREFIX = "v2:"
 
+
 def obj_to_uid(rooms):
     """Build unique id from sorted room names."""
     sorted_rooms = sorted(list(rooms))
@@ -121,7 +123,7 @@ def uid_to_obj(uid):
     """Build object (room list) from unique id."""
     if uid.startswith(UID_PREFIX):
         try:
-            json_str = base64.b64decode(uid[len(UID_PREFIX):].encode()).decode()
+            json_str = base64.b64decode(uid[len(UID_PREFIX) :].encode()).decode()
             return json.loads(json_str)
         except Exception:
             pass
@@ -141,9 +143,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     room_names = raumfeld.get_rooms()
     room_groups = raumfeld.get_groups()
     registry = entity_registry.async_get(hass)
-    entity_entries = entity_registry.async_entries_for_config_entry(
-        registry, config_entry.entry_id
-    )
+    entity_entries = entity_registry.async_entries_for_config_entry(registry, config_entry.entry_id)
     platform = entity_platform.current_platform.get()
     devices = []
 
@@ -156,9 +156,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     for entity in entity_entries:
         if not entity.entity_id.startswith(platform.domain):
-            log_info(
-                f"Entity '{entity.entity_id}' is not recognized as media player and will not be restored as such"
-            )
+            log_info(f"Entity '{entity.entity_id}' is not recognized as media player and will not be restored as such")
             continue
 
         rooms = uid_to_obj(entity.unique_id)
@@ -170,9 +168,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
                 devices.append(RaumfeldGroup(group, raumfeld))
                 raumfeld.eid_to_obj[entity.entity_id] = uid_to_obj(entity.unique_id)
         else:
-            log_info(
-                f"Media player entity '{entity.entity_id}' is not recognized as speaker group"
-            )
+            log_info(f"Media player entity '{entity.entity_id}' is not recognized as speaker group")
             raumfeld.eid_to_obj[entity.entity_id] = uid_to_obj(entity.unique_id)
 
     async_add_devices(devices)
@@ -184,9 +180,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
             cv.make_entity_service_schema(
                 {
                     vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.positive_int,
-                    vol.Optional("rooms"): vol.All(
-                        cv.ensure_list, [vol.In(room_names)]
-                    ),
+                    vol.Optional("rooms"): vol.All(cv.ensure_list, [vol.In(room_names)]),
                 }
             )
         ),
@@ -197,9 +191,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         vol.All(
             cv.make_entity_service_schema(
                 {
-                    vol.Optional("sound"): vol.All(
-                        cv.string, vol.In([SOUND_SUCCESS, SOUND_FAILURE])
-                    ),
+                    vol.Optional("sound"): vol.All(cv.string, vol.In([SOUND_SUCCESS, SOUND_FAILURE])),
                 }
             )
         ),
@@ -364,9 +356,7 @@ class RaumfeldGroup(MediaPlayerEntity):
             await self._raumfeld.async_restore_group(self._rooms)
             await self.async_update_transport_state()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_turn_off(self):
         """Turn the media player off."""
@@ -381,9 +371,7 @@ class RaumfeldGroup(MediaPlayerEntity):
                 await asyncio.sleep(DELAY_FAST_UPDATE_CHECKS)
             await self.async_update_transport_state()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_mute_volume(self, mute):
         """Mute the volume."""
@@ -391,9 +379,7 @@ class RaumfeldGroup(MediaPlayerEntity):
             await self._raumfeld.async_set_group_mute(self._rooms, mute)
             await self.async_update_mute()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_set_volume_level(self, volume):
         """Set volume level, range 0..1."""
@@ -403,9 +389,7 @@ class RaumfeldGroup(MediaPlayerEntity):
         elif self._is_spotify_sroom:
             await self._raumfeld.async_set_room_volume(self._room, raumfeld_vol)
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
         await self.async_update_volume_level()
 
     async def async_media_play(self):
@@ -415,9 +399,7 @@ class RaumfeldGroup(MediaPlayerEntity):
         elif self._is_spotify_sroom:
             await self._raumfeld.async_room_play(self._room)
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
         await self.async_update_transport_state()
 
     async def async_media_pause(self):
@@ -427,9 +409,7 @@ class RaumfeldGroup(MediaPlayerEntity):
         elif self._is_spotify_sroom:
             await self._raumfeld.async_room_pause(self._room)
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
         await self.async_update_transport_state()
 
     async def async_media_stop(self):
@@ -438,9 +418,7 @@ class RaumfeldGroup(MediaPlayerEntity):
             await self._raumfeld.async_group_stop(self._rooms)
             await self.async_update_transport_state()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_media_previous_track(self):
         """Send previous track command."""
@@ -449,9 +427,7 @@ class RaumfeldGroup(MediaPlayerEntity):
         elif self._is_spotify_sroom:
             await self._raumfeld.async_room_previous_track(self._room)
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
         await self.async_update_track_info()
 
     async def async_media_next_track(self):
@@ -461,9 +437,7 @@ class RaumfeldGroup(MediaPlayerEntity):
         elif self._is_spotify_sroom:
             await self._raumfeld.async_room_next_track(self._room)
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
         await self.async_update_track_info()
 
     async def async_media_seek(self, position):
@@ -473,9 +447,7 @@ class RaumfeldGroup(MediaPlayerEntity):
             await self._raumfeld.async_group_seek(self._rooms, raumfeld_pos)
             await self.async_update_track_info()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
@@ -487,12 +459,8 @@ class RaumfeldGroup(MediaPlayerEntity):
                     if media_id.startswith("http"):
                         play_uri = media_id
                     if media_id.startswith("media-source"):
-                        play_item = await media_source.async_resolve_media(
-                            self.hass, media_id, self.entity_id
-                        )
-                        play_uri = async_process_play_media_url(
-                            self.hass, play_item.url
-                        )
+                        play_item = await media_source.async_resolve_media(self.hass, media_id, self.entity_id)
+                        play_uri = async_process_play_media_url(self.hass, play_item.url)
                     else:
                         log_error(f"Unexpected media ID for media type: {media_type}")
                 elif media_type in [
@@ -519,9 +487,7 @@ class RaumfeldGroup(MediaPlayerEntity):
                         await self.async_turn_on()
                     was_playing = self._state == STATE_PLAYING
                     if announce and was_playing:
-                        log_debug(
-                            f"Trigger snapshot for '{self._rooms}' due to announcement"
-                        )
+                        log_debug(f"Trigger snapshot for '{self._rooms}' due to announcement")
                         await self.async_snapshot()
                     if state_was_off and announce:
                         log_debug(
@@ -529,119 +495,79 @@ class RaumfeldGroup(MediaPlayerEntity):
                             + "or group that is in off state"
                         )
                     else:
-                        fixed_announcement_volume = self._raumfeld.options[
-                            OPTION_FIXED_ANNOUNCEMENT_VOLUME
-                        ]
+                        fixed_announcement_volume = self._raumfeld.options[OPTION_FIXED_ANNOUNCEMENT_VOLUME]
                         if announce and fixed_announcement_volume:
-                            announcement_volume = (
-                                self._raumfeld.options[OPTION_ANNOUNCEMENT_VOLUME] / 100
-                            )
+                            announcement_volume = self._raumfeld.options[OPTION_ANNOUNCEMENT_VOLUME] / 100
                             await self.async_set_volume_level(announcement_volume)
-                        await self._raumfeld.async_set_av_transport_uri(
-                            self._rooms, play_uri
-                        )
+                        await self._raumfeld.async_set_av_transport_uri(self._rooms, play_uri)
                         self._attributes["last_content_id"] = play_uri
                         self._attributes["last_content_type"] = media_type
                     if announce and was_playing:
                         while self._state == STATE_PLAYING:
                             await asyncio.sleep(DELAY_FAST_UPDATE_CHECKS)
-                        log_debug(
-                            f"Trigger restore of snapshot for '{self._rooms}' due to announcement"
-                        )
+                        log_debug(f"Trigger restore of snapshot for '{self._rooms}' due to announcement")
                         await self.async_restore()
             else:
                 log_error(f"Playing of media type '{media_type}' not supported")
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_set_shuffle(self, shuffle):
         """Enable/disable shuffle mode."""
         if self._raumfeld.group_is_valid(self._rooms):
             if shuffle:
                 if self._repeat != RepeatMode.OFF:
-                    await self._raumfeld.async_set_play_mode(
-                        self._rooms, PLAY_MODE_RANDOM
-                    )
+                    await self._raumfeld.async_set_play_mode(self._rooms, PLAY_MODE_RANDOM)
                 else:
-                    await self._raumfeld.async_set_play_mode(
-                        self._rooms, PLAY_MODE_SHUFFLE
-                    )
+                    await self._raumfeld.async_set_play_mode(self._rooms, PLAY_MODE_SHUFFLE)
             elif self._play_mode == PLAY_MODE_SHUFFLE:
                 await self._raumfeld.async_set_play_mode(self._rooms, PLAY_MODE_NORMAL)
             elif self._play_mode == PLAY_MODE_RANDOM:
-                await self._raumfeld.async_set_play_mode(
-                    self._rooms, PLAY_MODE_REPEAT_ALL
-                )
+                await self._raumfeld.async_set_play_mode(self._rooms, PLAY_MODE_REPEAT_ALL)
             else:
                 log_fatal(f"Invalid shuffle mode: {shuffle}")
             await self.async_update_play_mode()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_set_repeat(self, repeat):
         """Set repeat mode."""
         if self._raumfeld.group_is_valid(self._rooms):
             if repeat == RepeatMode.ALL:
                 if self._shuffle:
-                    await self._raumfeld.async_set_play_mode(
-                        self._rooms, PLAY_MODE_RANDOM
-                    )
+                    await self._raumfeld.async_set_play_mode(self._rooms, PLAY_MODE_RANDOM)
                 else:
-                    await self._raumfeld.async_set_play_mode(
-                        self._rooms, PLAY_MODE_REPEAT_ALL
-                    )
+                    await self._raumfeld.async_set_play_mode(self._rooms, PLAY_MODE_REPEAT_ALL)
             elif repeat == RepeatMode.ONE:
-                await self._raumfeld.async_set_play_mode(
-                    self._rooms, PLAY_MODE_REPEAT_ONE
-                )
+                await self._raumfeld.async_set_play_mode(self._rooms, PLAY_MODE_REPEAT_ONE)
             elif repeat == RepeatMode.OFF:
                 if self._shuffle:
-                    await self._raumfeld.async_set_play_mode(
-                        self._rooms, PLAY_MODE_SHUFFLE
-                    )
+                    await self._raumfeld.async_set_play_mode(self._rooms, PLAY_MODE_SHUFFLE)
                 else:
-                    await self._raumfeld.async_set_play_mode(
-                        self._rooms, PLAY_MODE_NORMAL
-                    )
+                    await self._raumfeld.async_set_play_mode(self._rooms, PLAY_MODE_NORMAL)
             else:
                 log_fatal(f"Invalid repeate mode: {repeat}")
             await self.async_update_play_mode()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_volume_up(self):
         """Turn volume up for media player."""
         if self._raumfeld.group_is_valid(self._rooms):
             change_step_volume = self._raumfeld.options[OPTION_CHANGE_STEP_VOLUME_UP]
-            await self._raumfeld.async_change_group_volume(
-                self._rooms, change_step_volume
-            )
+            await self._raumfeld.async_change_group_volume(self._rooms, change_step_volume)
             await self.async_update_volume_level()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_volume_down(self):
         """Turn volume down for media player."""
         if self._raumfeld.group_is_valid(self._rooms):
-            change_step_volume = (
-                -1 * self._raumfeld.options[OPTION_CHANGE_STEP_VOLUME_DOWN]
-            )
-            await self._raumfeld.async_change_group_volume(
-                self._rooms, change_step_volume
-            )
+            change_step_volume = -1 * self._raumfeld.options[OPTION_CHANGE_STEP_VOLUME_DOWN]
+            await self._raumfeld.async_change_group_volume(self._rooms, change_step_volume)
             await self.async_update_volume_level()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         """Implement the websocket media browsing helper."""
@@ -700,9 +626,7 @@ class RaumfeldGroup(MediaPlayerEntity):
                     log_fatal(f"Unrecognized transport state: {transport_state}")
                     self._state = STATE_OFF
             else:
-                log_debug(
-                    f"Method was called although speaker group '{self._rooms}' is invalid"
-                )
+                log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
             break
 
     async def async_update_volume_level(self):
@@ -778,9 +702,7 @@ class RaumfeldGroup(MediaPlayerEntity):
         if self._raumfeld.group_is_valid(self._rooms):
             await self._raumfeld.async_save_group(self._rooms)
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_play_system_sound(self, sound=SOUND_SUCCESS):
         """Play system sound 'Success' or 'Failure'."""
@@ -788,31 +710,23 @@ class RaumfeldGroup(MediaPlayerEntity):
             for room in self._rooms:
                 await self._raumfeld.async_room_play_system_sound(room, sound)
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_restore(self):
         """Restore previously saved media and position of the player."""
         if self._raumfeld.group_is_valid(self._rooms):
             await self._raumfeld.async_restore_group(self._rooms)
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_set_rooms_volume_level(self, volume_level, rooms=None):
         """Set volume level, range 0..100."""
         if self._raumfeld.group_is_valid(self._rooms):
             raumfeld_vol = volume_level
-            await self._raumfeld.async_set_group_room_volume(
-                self._rooms, raumfeld_vol, rooms
-            )
+            await self._raumfeld.async_set_group_room_volume(self._rooms, raumfeld_vol, rooms)
             await self.async_update_volume_level()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
 
 class RaumfeldRoom(RaumfeldGroup):
@@ -845,9 +759,7 @@ class RaumfeldRoom(RaumfeldGroup):
             await self._raumfeld.async_add_rooms_to_group(room_lst, self._rooms)
             await self.async_update_transport_state()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is invalid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is invalid")
 
     async def async_unjoin_player(self):
         """Remove this player from any group."""
@@ -855,9 +767,7 @@ class RaumfeldRoom(RaumfeldGroup):
             await self._raumfeld.async_drop_room_from_group(self._room)
             await self.async_update_transport_state()
         else:
-            log_debug(
-                f"Method was called although speaker group '{self._rooms}' is valid"
-            )
+            log_debug(f"Method was called although speaker group '{self._rooms}' is valid")
 
     async def async_update(self):
         """Update entity"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ target-version = "py313"
 line-length = 125
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP"]
+select = ["E", "F", "I", "N", "W", "UP", "TD"]
+ignore = ["TD003"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["custom_components"]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -72,9 +72,7 @@ class TestConfigFlowUserStep:
         ) as mock_validate:
             mock_validate.return_value = {"title": "Raumfeld host: 192.168.1.100"}
 
-            result = await flow.async_step_user(
-                user_input={"host": "192.168.1.100", "port": "47365"}
-            )
+            result = await flow.async_step_user(user_input={"host": "192.168.1.100", "port": "47365"})
             assert result["type"] == "create_entry"
             assert result["title"] == "Raumfeld host: 192.168.1.100"
             assert result["data"]["host"] == "192.168.1.100"
@@ -95,9 +93,7 @@ class TestConfigFlowUserStep:
         ) as mock_validate:
             mock_validate.side_effect = CannotConnect
 
-            result = await flow.async_step_user(
-                user_input={"host": "bad-host", "port": "47365"}
-            )
+            result = await flow.async_step_user(user_input={"host": "bad-host", "port": "47365"})
             assert result["type"] == "form"
             assert result["errors"]["base"] == "cannot_connect"
 
@@ -114,9 +110,7 @@ class TestConfigFlowUserStep:
         ) as mock_validate:
             mock_validate.side_effect = RuntimeError("Boom")
 
-            result = await flow.async_step_user(
-                user_input={"host": "bad-host", "port": "47365"}
-            )
+            result = await flow.async_step_user(user_input={"host": "bad-host", "port": "47365"})
             assert result["type"] == "form"
             assert result["errors"]["base"] == "unknown"
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -80,9 +80,7 @@ class TestMkPlayUri:
         self.host.media_server_udn = "uuid:test-ms-udn"
 
     def test_album_uri(self):
-        uri = self.host.mk_play_uri(
-            self.host.media_server_udn, UPNP_CLASS_ALBUM, "0/My Music/Albums/Test"
-        )
+        uri = self.host.mk_play_uri(self.host.media_server_udn, UPNP_CLASS_ALBUM, "0/My Music/Albums/Test")
         assert uri is not None
         assert uri.startswith("dlna-playcontainer://")
 
@@ -96,9 +94,7 @@ class TestMkPlayUri:
         assert uri.startswith("dlna-playcontainer://")
 
     def test_track_uri_has_fid(self):
-        uri = self.host.mk_play_uri(
-            self.host.media_server_udn, UPNP_CLASS_TRACK, "0/My Music/Albums/Test/1.mp3"
-        )
+        uri = self.host.mk_play_uri(self.host.media_server_udn, UPNP_CLASS_TRACK, "0/My Music/Albums/Test/1.mp3")
         assert "&fid=" in uri
 
     def test_podcast_episode_has_fid(self):
@@ -110,9 +106,7 @@ class TestMkPlayUri:
         assert "&fid=" in uri
 
     def test_radio_uri(self):
-        uri = self.host.mk_play_uri(
-            self.host.media_server_udn, UPNP_CLASS_RADIO, "0/RadioTime/Stations/WDR2"
-        )
+        uri = self.host.mk_play_uri(self.host.media_server_udn, UPNP_CLASS_RADIO, "0/RadioTime/Stations/WDR2")
         assert uri.startswith("dlna-playsingle://")
         assert "&iid=" in uri
 
@@ -126,21 +120,15 @@ class TestMkPlayUri:
 
     def test_line_in_non_matching_oid_returns_none(self):
         self.host.device_udn_to_location = MagicMock()
-        uri = self.host.mk_play_uri(
-            self.host.media_server_udn, UPNP_CLASS_LINE_IN, "0/SomeOther"
-        )
+        uri = self.host.mk_play_uri(self.host.media_server_udn, UPNP_CLASS_LINE_IN, "0/SomeOther")
         assert uri is None
 
     def test_audio_item_fallback(self):
-        uri = self.host.mk_play_uri(
-            self.host.media_server_udn, UPNP_CLASS_AUDIO_ITEM, "some_id"
-        )
+        uri = self.host.mk_play_uri(self.host.media_server_udn, UPNP_CLASS_AUDIO_ITEM, "some_id")
         assert uri == "some_id"
 
     def test_album_uri_correct_params(self):
-        uri = self.host.mk_play_uri(
-            self.host.media_server_udn, UPNP_CLASS_ALBUM, "0/Albums/5"
-        )
+        uri = self.host.mk_play_uri(self.host.media_server_udn, UPNP_CLASS_ALBUM, "0/Albums/5")
         assert "?sid=" in uri
         assert "&cid=" in uri
         assert "&md=0" in uri
@@ -162,9 +150,7 @@ class TestAsyncBrowseMedia:
     @pytest.mark.asyncio
     async def test_separator_stripped(self):
         self.host.async_browse_media_server = AsyncMock(return_value=None)
-        await self.host.async_browse_media(
-            object_id=f"0/My Music{MEDIA_CONTENT_ID_SEP}dlna-playsingle://..."
-        )
+        await self.host.async_browse_media(object_id=f"0/My Music{MEDIA_CONTENT_ID_SEP}dlna-playsingle://...")
         called_oid = self.host.async_browse_media_server.call_args[0][0]
         assert called_oid == "0/My Music"
 
@@ -175,11 +161,11 @@ class TestAsyncBrowseMedia:
             ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
             '<container id="0/My Music" childCount="5" restricted="1">'
             "<dc:title>My Music</dc:title>"
-            '<upnp:class>object.container.storageFolder</upnp:class>'
+            "<upnp:class>object.container.storageFolder</upnp:class>"
             "</container>"
             '<item id="0/My Music/Track1.mp3" restricted="1">'
             "<dc:title>Test Track</dc:title>"
-            '<upnp:class>object.item.audioItem.musicTrack</upnp:class>'
+            "<upnp:class>object.item.audioItem.musicTrack</upnp:class>"
             "</item>"
             "</DIDL-Lite>"
         )
@@ -202,11 +188,11 @@ class TestAsyncBrowseMedia:
             ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
             '<container id="0/My Music/Search" childCount="0" restricted="1">'
             "<dc:title>Search</dc:title>"
-            '<upnp:class>object.container</upnp:class>'
+            "<upnp:class>object.container</upnp:class>"
             "</container>"
             '<item id="0/My Music/Track1.mp3" restricted="1">'
             "<dc:title>Valid Track</dc:title>"
-            '<upnp:class>object.item.audioItem.musicTrack</upnp:class>'
+            "<upnp:class>object.item.audioItem.musicTrack</upnp:class>"
             "</item>"
             "</DIDL-Lite>"
         )
@@ -224,7 +210,7 @@ class TestAsyncBrowseMedia:
             '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"'
             ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
             '<container id="0/My Music" childCount="5" restricted="1">'
-            '<upnp:class>object.container.storageFolder</upnp:class>'
+            "<upnp:class>object.container.storageFolder</upnp:class>"
             "</container>"
             "</DIDL-Lite>"
         )

--- a/tests/test_media_browser.py
+++ b/tests/test_media_browser.py
@@ -28,9 +28,7 @@ class TestAsyncBrowseMedia:
         host = HassRaumfeldHost(host="127.0.0.1")
         host.async_browse_media_server = AsyncMock(return_value=None)
 
-        result = await host.async_browse_media(
-            object_id=f"0/My Music{MEDIA_CONTENT_ID_SEP}some_uri"
-        )
+        result = await host.async_browse_media(object_id=f"0/My Music{MEDIA_CONTENT_ID_SEP}some_uri")
 
         assert result == []
         # Should have called browse with the part before the separator

--- a/tests/test_media_player_entity.py
+++ b/tests/test_media_player_entity.py
@@ -68,9 +68,7 @@ class TestRaumfeldGroupVolume:
 
         await self.group.async_volume_up()
 
-        self.raumfeld.async_change_group_volume.assert_called_once_with(
-            self.rooms, 5
-        )
+        self.raumfeld.async_change_group_volume.assert_called_once_with(self.rooms, 5)
 
     @pytest.mark.asyncio
     async def test_volume_down_calls_change_group_volume(self):
@@ -80,9 +78,7 @@ class TestRaumfeldGroupVolume:
 
         await self.group.async_volume_down()
 
-        self.raumfeld.async_change_group_volume.assert_called_once_with(
-            self.rooms, -2
-        )
+        self.raumfeld.async_change_group_volume.assert_called_once_with(self.rooms, -2)
 
     @pytest.mark.asyncio
     async def test_volume_up_invalid_group_logs(self):
@@ -99,9 +95,7 @@ class TestRaumfeldGroupVolume:
 
         await self.group.async_set_volume_level(0.75)
 
-        self.raumfeld.async_set_group_volume.assert_called_once_with(
-            self.rooms, 75
-        )
+        self.raumfeld.async_set_group_volume.assert_called_once_with(self.rooms, 75)
 
 
 class TestRaumfeldGroupMute:
@@ -121,9 +115,7 @@ class TestRaumfeldGroupMute:
 
         await self.group.async_mute_volume(True)
 
-        self.raumfeld.async_set_group_mute.assert_called_once_with(
-            self.rooms, True
-        )
+        self.raumfeld.async_set_group_mute.assert_called_once_with(self.rooms, True)
 
     @pytest.mark.asyncio
     async def test_mute_false(self):
@@ -133,9 +125,7 @@ class TestRaumfeldGroupMute:
 
         await self.group.async_mute_volume(False)
 
-        self.raumfeld.async_set_group_mute.assert_called_once_with(
-            self.rooms, False
-        )
+        self.raumfeld.async_set_group_mute.assert_called_once_with(self.rooms, False)
 
 
 class TestRaumfeldGroupTransport:

--- a/tests/test_unique_id.py
+++ b/tests/test_unique_id.py
@@ -40,16 +40,12 @@ class TestObjToUid:
     def test_single_room(self):
         """Single-room group works correctly."""
         uid = obj_to_uid(["Wohnzimmer"])
-        assert uid == UID_PREFIX + base64.b64encode(
-            json.dumps(["Wohnzimmer"], sort_keys=True).encode()
-        ).decode().strip()
+        assert uid == UID_PREFIX + base64.b64encode(json.dumps(["Wohnzimmer"], sort_keys=True).encode()).decode().strip()
 
     def test_empty_list(self):
         """Empty room list works correctly."""
         uid = obj_to_uid([])
-        assert uid == UID_PREFIX + base64.b64encode(
-            json.dumps([], sort_keys=True).encode()
-        ).decode().strip()
+        assert uid == UID_PREFIX + base64.b64encode(json.dumps([], sort_keys=True).encode()).decode().strip()
 
 
 class TestUidToObj:


### PR DESCRIPTION
## What

Automates the style checks recommended by the [Home Assistant development guidelines](https://developers.home-assistant.io/docs/development_guidelines/).

## Changes

### CI (ci.yaml)
- Add `ruff format --check` step to lint job — catches unformatted code before merge

### pyproject.toml
- Enable ruff TD rules (`flake8-todo`) — enforces TODO format: `# TODO(@author): description.`
- Suppress TD003 (issue links) — too aggressive for pre-existing template TODOs

### .pre-commit-config.yaml (new)
- Local pre-commit hooks for ruff (lint + format)
- Developers run `pre-commit install` once, then every commit is auto-checked

### Source fixes
- Fix two TODO comments: add @B5r1oJ0A9G author and proper colon format with trailing period
- Reformat all 10 Python files with `ruff format`

## Verification

All checks pass locally:
- `ruff format --check`: 13 files already formatted ✅
- `ruff check`: All checks passed ✅
- `mypy`: Success ✅
- `pytest`: 81 passed ✅